### PR TITLE
Override `send` instead of `request`

### DIFF
--- a/requests_futures/sessions.py
+++ b/requests_futures/sessions.py
@@ -69,7 +69,7 @@ class FuturesSession(Session):
         func = super(FuturesSession, self).send
         if isinstance(self.executor, ProcessPoolExecutor):
             try:
-                dumps(request)
+                dumps(func)
             except (TypeError, PickleError):
                 raise RuntimeError(PICKLE_ERROR)
         return self.executor.submit(func, request, **kwargs)

--- a/requests_futures/sessions.py
+++ b/requests_futures/sessions.py
@@ -66,12 +66,17 @@ class FuturesSession(Session):
         self.session = session
 
     def send(self, request, **kwargs):
-        func = super(FuturesSession, self).send
+        if self.session:
+            func = self.session.send
+        else:
+            func = partial(Session.send, self)
+
         if isinstance(self.executor, ProcessPoolExecutor):
             try:
                 dumps(func)
             except (TypeError, PickleError):
                 raise RuntimeError(PICKLE_ERROR)
+
         return self.executor.submit(func, request, **kwargs)
 
     def close(self):


### PR DESCRIPTION
By wrapping `send` instead of `request`, we can allow prepared requests to be async as well. I'm not sure if we really need the pickle check since we are wrapping `super`'s `send` method. 