### PR TITLE
fix(futures-session): increase number of max workers to five

### DIFF
--- a/gain_requests_futures/sessions.py
+++ b/gain_requests_futures/sessions.py
@@ -40,7 +40,7 @@ PICKLE_ERROR = (
 
 class FuturesSession(Session):
 
-    def __init__(self, executor=None, max_workers=2, session=None, *args,
+    def __init__(self, executor=None, max_workers=5, session=None, *args,
                  **kwargs):
         """Creates a FuturesSession
 

--- a/test_requests_futures.py
+++ b/test_requests_futures.py
@@ -76,9 +76,9 @@ class RequestsTestCase(TestCase):
         """ Tests the `max_workers` shortcut. """
         from concurrent.futures import ThreadPoolExecutor
         session = FuturesSession()
-        self.assertEqual(session.executor._max_workers, 2)
-        session = FuturesSession(max_workers=5)
         self.assertEqual(session.executor._max_workers, 5)
+        session = FuturesSession(max_workers=2)
+        self.assertEqual(session.executor._max_workers, 2)
         session = FuturesSession(executor=ThreadPoolExecutor(max_workers=10))
         self.assertEqual(session.executor._max_workers, 10)
         session = FuturesSession(executor=ThreadPoolExecutor(max_workers=10),


### PR DESCRIPTION
urlfetch allows 10 so I think we can safely try 5 as a default.  when looking at performance 
issues I noticed that large data rows calls looked pretty "waterfall-y" so I think this
would help